### PR TITLE
v1.0.6 -> fix previous patch `train` bug

### DIFF
--- a/fastprop/cli/base.py
+++ b/fastprop/cli/base.py
@@ -94,7 +94,7 @@ def main():
         training_default = dict(DEFAULT_TRAINING_CONFIG)
         optim_requested = args.pop("optimize")
         if args["config_file"] is not None:
-            if sum(map(lambda i: i is not None, args.values())) > 1:
+            if any(value is not None and arg_name not in {"clamp_input", "config_file"} for arg_name, value in args.items()):
                 raise parser.error("Cannot specify config_file with other command line arguments (except --optimize).")
             with open(args["config_file"], "r") as f:
                 cfg = yaml.safe_load(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastprop"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
     { name = "Jackson Burns" },
 ]


### PR DESCRIPTION
Previous patch release introduced a bug which would prevent calling `fastprop train` using a configuration file, unless performing hyperparameter optimization. This release will fix said bug!